### PR TITLE
docs(readme): fix link to Spleen in AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ GitHub: https://github.com/fcambus/spleen
 [9]: https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/fonts/spleen/
 [10]: https://pkgsrc.se/fonts/spleen
 [11]: https://www.freshports.org/x11-fonts/spleen/
-[12]: https://aur.archlinux.org/packages/bdf-spleen/
+[12]: https://aur.archlinux.org/packages/spleen-font/
 [13]: https://github.com/void-linux/void-packages/tree/master/srcpkgs/font-spleen
 [14]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/data/fonts/spleen
 [15]: https://packages.debian.org/search?keywords=spleen


### PR DESCRIPTION
closes #18 

The old package probably was orphaned and a new maintainer picked it up under a different name.