### PR TITLE
Update Makefile to use modern iteration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ FONTSET =	$(DATADIR)/fontsets/Uni1.512+:$(ASCII)+:$(LINUX)+:$(USEFUL)
 OPTIONS =	$(EQUIVALENT) $(FONTSET) 512
 
 SIZES =		5x8 6x12 8x16 12x24 16x32 32x64
-OTFSIZES =	6x12 8x16 12x24 16x32 32x64
 
 TARGET =	all
 
@@ -48,82 +47,88 @@ all:	com pcf psf fon otb sfd otf
 com:
 	$(MAKE) -C dos
 
-pcf:
-.for size in $(SIZES)
-	$(BDFTOPCF) -t -o spleen-${size}.pcf spleen-${size}.bdf
-.endfor
+%.pcf: %.bdf
+        $(BDFTOPCF) -t -o $< $@
 
-psf:
-.for size in $(SIZES)
-	$(BDF2PSF) --fb spleen-${size}.bdf $(OPTIONS) spleen-${size}.psfu
-.endfor
+pcf: $(addprefix spleen-,$(SIZES:=.pcf))
 
-fon:
-.for size in $(SIZES)
-	$(FONTFORGE) -lang ff -c 'Open("spleen-${size}.bdf"); Generate("spleen-${size}.fon")'
-.endfor
+%.psfu: %.bdf
+        $(BDF2PSF) --fb $< $(OPTIONS) $@ 2>1 | grep -Ev "^WARNING: "
 
-otb:
-.for size in $(SIZES)
-	$(FONTTOSFNT) -b -c -o spleen-${size}.otb spleen-${size}.bdf
-.endfor
+# No PSF-based console supports 32x64 bitmap fonts, so filter that size out
+psf: $(addprefix spleen-,$(filter-out 32x64.%,$(SIZES:=.psfu)))
 
-sfd:
-.for size in $(OTFSIZES)
-	$(BDF2SFD) -f "Spleen ${size}" -p "Spleen${size}" spleen-${size}.bdf > spleen-${size}.sfd
-	$(FONTFORGE) -lang ff -c 'Open("spleen-${size}.sfd"); SelectAll(); RemoveOverlap(); Simplify(-1, 1); Save("spleen-${size}.sfd")'
-.endfor
+%.fon: %.bdf
+        $(FONTFORGE) -lang ff -c 'Open("$<"); Generate("$@")'
 
-otf:
-.for size in $(OTFSIZES)
-	$(FONTFORGE) -lang ff -c 'Open("spleen-${size}.sfd"); Generate("spleen-${size}.otf")'
-.endfor
+fon: $(addprefix spleen-,$(SIZES:=.fon))
 
-screenshots:
-.for size in $(SIZES)
-	awk 'BEGIN { for(chr = 32; chr < 127; chr++) printf "%c", chr }' | \
-	$(PBMTEXT) -font spleen-${size}.bdf -nomargins | \
-	$(PPMCHANGE) black "#aaa" | \
-	$(PPMCHANGE) white black | \
-	$(PNMTOPNG) > spleen-${size}.png
-.endfor
-	$(OXIPNG) -o max *.png
+%.otb: %.bdf
+        $(FONTTOSFNT) -b -c -o %@ %<
+
+otb: $(addprefix spleen-,$(SIZES:=.otb))
+
+%.sfd: %.bdf
+        $(eval SIZE := $(subst .bdf,,$(subst spleen-,,$<)))
+        $(BDF2SFD) -f "Spleen $(SIZE)" -p "Spleen$(SIZE)" %< > %@
+        $(FONTFORGE) -lang ff -c 'Open("$@"); SelectAll(); RemoveOverlap(); Simplify(-1, 1); Save("%@")'
+
+sfd: $(addprefix spleen-,$(SIZES:=.sfd))
+
+%.otf: %.sfd
+        $(eval SIZE := $(subst .sfd,,$(subst spleen-,,$<)))
+        $(FONTFORGE) -lang ff -c 'Open("spleen-$(SIZE).sfd"); Generate("spleen-$(SIZE).otf")'
+
+# Filter out 5x8 as it's a different aspect ratio to the other font sizes
+otf: $(addprefix spleen-,$(filter-out 5x8.%,$(SIZES:=.otf)))
+
+%.png: %.bdf
+        awk 'BEGIN { for(chr = 32; chr < 127; chr++) printf "%c", chr }' | \
+        $(PBMTEXT) -font %< -nomargins | \
+        $(PPMCHANGE) black "#aaa" | \
+        $(PPMCHANGE) white black | \
+        $(PNMTOPNG) > %@
+        $(OXIPNG) -o max %@
+
+screenshots: $(addprefix spleen-,$(SIZES:=.png))
 
 specimen:
-	printf "\n  Spleen         " | \
-	$(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
-	$(PPMCHANGE) white "#ff7f2a" | \
-	$(PPMCHANGE) black "#fff" > spleen.pnm
+        printf "\n  Spleen         " | \
+        $(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
+        $(PPMCHANGE) white "#ff7f2a" | \
+        $(PPMCHANGE) black "#fff" > spleen.pnm
 
-	printf "\n  Aa Ee Gg       \n  Qq Rr Ss" | \
-	$(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
-	$(PPMCHANGE) white "#ff7f2a" > examples.pnm
+        printf "\n  Aa Ee Gg       \n  Qq Rr Ss" | \
+        $(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
+        $(PPMCHANGE) white "#ff7f2a" > examples.pnm
 
-	printf "\n     The future  " | \
-	$(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
-	$(PPMCHANGE) white "#ff7f2a" | \
-	$(PPMCHANGE) black "#fff" > future.pnm
+        printf "\n     The future  " | \
+        $(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
+        $(PPMCHANGE) white "#ff7f2a" | \
+        $(PPMCHANGE) black "#fff" > future.pnm
 
-	printf "  abcdefghijklm  \n  nopqrstuvwxyz" | \
-	$(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
-	$(PPMCHANGE) white "#ff2a7f" > letters.pnm
+        printf "  abcdefghijklm  \n  nopqrstuvwxyz" | \
+        $(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
+        $(PPMCHANGE) white "#ff2a7f" > letters.pnm
 
-	printf "     0123456789  " | \
-	$(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
-	$(PPMCHANGE) white "#ff2a7f" | \
-	$(PPMCHANGE) black "#fff"  > digits.pnm
+        printf "     0123456789  " | \
+        $(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
+        $(PPMCHANGE) white "#ff2a7f" | \
+        $(PPMCHANGE) black "#fff"  > digits.pnm
 
-	$(PNMCAT) -tb spleen.pnm examples.pnm future.pnm letters.pnm digits.pnm > specimen.pnm
+        $(PNMCAT) -tb spleen.pnm examples.pnm future.pnm letters.pnm digits.pnm > specimen.pnm
+        $(RM) spleen.pnm examples.pnm future.pnm letters.pnm digits.pnm
 
-	printf "a" | \
-	$(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
-	$(PPMCHANGE) white "#ff7f2a" | \
-	$(PPMCHANGE) black "#fff" | \
-	$(PNMSCALE) 4 | \
-	$(PNMPASTE) - 364 100 specimen.pnm | \
-	$(PNMTOPNG) > specimen.png
-	rm *.pnm
-	$(OXIPNG) -o max *.png
+        printf "a" | \
+        $(PBMTEXT) -font spleen-32x64.bdf -nomargins | \
+        $(PPMCHANGE) white "#ff7f2a" | \
+        $(PPMCHANGE) black "#fff" | \
+        $(PNMSCALE) 4 | \
+        $(PNMPASTE) - 364 100 specimen.pnm | \
+        $(PNMTOPNG) > specimen.png
+
+        $(RM) specimen.pnm
+        $(OXIPNG) -o max specimen.png
 
 clean:
-	rm -f *.bak *.dfont *.fon *.gz *.sfd *.otb *.otf *.pcf *.psfu spleen*.png
+        $(RM) *.bak *.dfont *.fon *.gz *.sfd *.otb *.otf *.pcf *.psfu spleen*.png


### PR DESCRIPTION
The current Makefile uses some vendor-specific method of looping over the SIZES variable.

This updates it to use normal Makefile pattern substitution design which is more universally compatible and also can be run fully in parallel.

I also modified the PSF and OTF generation to integrate appropriate size filters with comments explaining why.

While some other OS platforms support the 32x64 font size that is not supported by the Linux kernel as it has [a hard limit on console fonts of 32x32](https://github.com/torvalds/linux/commit/2b09d5d364986f724f17001ccfe4126b9b43a0be) due to internal implementation details.